### PR TITLE
Fixing an issue where case nodes could not be deleted

### DIFF
--- a/yanggui/dataeditor.py
+++ b/yanggui/dataeditor.py
@@ -85,7 +85,7 @@ class SchemaNodeEntry:
                 btn = self.buttons['CreateDelete']['obj']
                 btn.Value = (data != None)
                 btn.SetToolTip(self.buttons['CreateDelete']['tooltip'][data != None])
-                if self.parent.schemaNode.mandatory:
+                if self.parent.schemaNode.mandatory and not isinstance(self.parent.nodeParent.schemaNode, yangson.schemanode.CaseNode):
                     btn.Show(data == None)
 
         def _AddButtons(self, buttons):


### PR DESCRIPTION
- If case nodes are mandatory, still only one of the case nodes may exist
- Case nodes are now expected from the hidden add button to allow removing single case nodes