### PR TITLE
PR for release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    version='0.1.1',
+    version='0.1.2',
     name = "yanggui",
     python_requires=">=3.6",
     install_requires=[
         'wxPython>=4.1',
-        'yangson>=1.4',
+        'yangson>=1.4.9',
         'rstr>=2.2',
         'PyPubSub>=4',
     ],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    version='0.1.0',
+    version='0.1.1',
     name = "yanggui",
     python_requires=">=3.6",
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    version='0.1.2',
+    version='0.1.3',
     name = "yanggui",
     python_requires=">=3.6",
     install_requires=[

--- a/yanggui/dataeditor.py
+++ b/yanggui/dataeditor.py
@@ -748,12 +748,12 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
             return '0x{}'.format(data.value.hex())
         
     class YangStringProperty(YangLinearProperty):
-        def GetDefaultData(self):
+        def GetDefaultValue(self):
             if hasattr(self.type, 'patterns') and len(self.type.patterns) > 0:
-                data = rstr.xeger(self.type.patterns[0].regex)
+                value = rstr.xeger(self.type.patterns[0].regex)
             else:
-                data = rstr.rstr('x', self.minLength)
-            return data
+                value = rstr.rstr('x', self.minLength)
+            return value
         
         def _ParseInstDataFromValue(self, value):
             if value == "":
@@ -777,7 +777,7 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
                 if isinstance(self.type.range, yangson.constraint.Intervals):
                     self.default = self.type.range.intervals[0][0]
 
-        def GetDefaultData(self):
+        def GetDefaultValue(self):
             return self.default
         
     class YangChoiceProperty(wxpg.EnumProperty, YangPropertyBase):
@@ -844,8 +844,8 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
             return json.dumps(data.value)
 
     class YangDecimal64Property(YangGenericProperty):
-        def GetDefaultData(self):
-            return 0.0
+        def GetDefaultValue(self):
+            return "0.0"
 
     class YangInternalProperty(wxpg.StringProperty, YangPropertyBase):
         def __init__(self, parent, sn):

--- a/yanggui/dataeditor.py
+++ b/yanggui/dataeditor.py
@@ -537,9 +537,13 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
             else:
                 if d == None: # data should be created
                     p = self.env['dsrepo'].get_resource(self.parent.path)
+                    if p == None:
+                        validationInfo.FailureMessage = 'Cannot assign value as the parent node does not exist. Please create the node first.'
+                        return False
                     updated = p.put_member(name=self.schemaNode.iname(), value=data)
                 else:
                     updated = d.update(data)
+                    
                 try:
                     updated.validate()
                 except:

--- a/yanggui/dataeditor.py
+++ b/yanggui/dataeditor.py
@@ -655,7 +655,11 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
                 return obj
 
         def GetDefaultData(self):
-            return self._ParseInstDataFromValue(self.GetDefaultValue())
+            if hasattr(self.schemaNode, 'default') and self.schemaNode.default != None:
+                data = self.schemaNode.default
+            else:
+                data = self._ParseInstDataFromValue(self.GetDefaultValue())
+            return data
             
         def ConvertDataToObject(self, data):
             return data
@@ -789,7 +793,7 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
             self.SetEditor("YangChoiceEditor")
             self.SetValueToUnspecified()
 
-        def GetDefaultData(self):
+        def GetDefaultValue(self):
             return False
 
         def _ParseInstDataFromValue(self, value):

--- a/yanggui/dataeditor.py
+++ b/yanggui/dataeditor.py
@@ -897,7 +897,7 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
                     value = '{}{}: {}, '.format(value, iname, child_value)
                     if(len(value) > 100):
                         break
-                if(len(value) > 100):
+                if len(value) > 100:
                     value = value[0:100].rsplit(',', 1)[0] + ' ...'
                 else:
                     value = value.rsplit(',', 1)[0]
@@ -1002,13 +1002,6 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
             return yangson.instvalue.ArrayValue(val=data)
         
         def ValidateValue(self, value, validationInfo):
-            path = self.path[0:-1] + (int(value), )
-            d = self.env['dsrepo'].get_resource(path)
-            if d != None:
-                self.Select(int(value))
-            else:
-                validationInfo.FailureMessage = 'List index out of bounds.'
-                return False
             return True
         
         def _ConvertInstDataToValue(self, data):

--- a/yanggui/dataeditor.py
+++ b/yanggui/dataeditor.py
@@ -222,9 +222,10 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
                 
             if (property.env['southboundIf'] != None) and (property.env['southboundIf'].resources != None):
                 if property.schemaNode.data_path() in property.env['southboundIf'].resources:
-                    if property.schemaNode.config and dataValid:
-                        buttons.AddButton("P", id=self.PUT)
                     buttons.AddButton("G", id=self.GET)
+                    if dataValid:
+                        if property.schemaNode.config:
+                            buttons.AddButton("P", id=self.PUT)
             if dataValid:
                 buttons.AddButton("ADV", id=self.ADVANCED)
             wndList = super().CreateControls(
@@ -349,6 +350,7 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
                     self.Put(aProperty)
                 elif evtId == self.GET:
                     self.Get(aProperty)
+                    aProperty.RecreateEditor()
                 elif evtId == self.ADVANCED:
                     self.AdvancedMenu(aProperty)
                 return False
@@ -363,6 +365,9 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
         def Get(self, prop):
             if prop.env['southboundIf'] != None:
                 data = prop.env['dsrepo'].get_resource(prop.path)
+                if data == None:
+                    prop.Create()
+                    data = prop.env['dsrepo'].get_resource(prop.path)
                 data = prop.env['southboundIf'].get(prop.env['dsrepo'].dm, data, prop.path)
                 if data != None:
                     prop.env['dsrepo'].commit(data.top())

--- a/yanggui/dataeditor.py
+++ b/yanggui/dataeditor.py
@@ -354,6 +354,12 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
             wxpg.PGTextCtrlEditor.__init__(self)
             YangPropertyGrid.YangEditor.__init__(self)
 
+        def CreateControls(self, propGrid, property, pos, sz):
+            wndList = super().CreateControls(propGrid, property, pos, sz)
+            if hasattr(property, 'maxLength'):
+                wndList.Primary.SetMaxLength(property.maxLength)
+            return wndList
+
     class YangListEditor(YangEditor, wxpg.PGTextCtrlEditor):
         LISTEDIT = wx.ID_HIGHEST + 20
         def __init__(self):
@@ -646,12 +652,15 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
                     if len(interval) == 2:
                         self.minLength = interval[0]
                         self.maxLength = interval[1]
+                        
+                        print(self.schemaNode.iname())
                     else:
                         self.minLength = interval[0]
 
     class YangBinaryProperty(YangLinearProperty):
         def __init__(self, parent, sn, sntype):
             super().__init__(parent, sn, sntype)
+            self.maxLength = self.minLength * 2 + 2 # add 2 chars for 0x prefixing, * 2 for binary to string
             # Set monospaced font
             cell = self.GetCell(0)
             font = wx.Font()

--- a/yanggui/dataeditor.py
+++ b/yanggui/dataeditor.py
@@ -419,7 +419,7 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
             return lb
 
         def _GetUpdatedData(self, data):
-            return data.update(self.lb.CheckedStrings).top()
+            return data.update(self.ctrl.CheckedStrings).top()
 
     class YangBitsEditor(YangEditor, wxpg.PGTextCtrlEditor):
         BITSEDIT = wx.ID_HIGHEST + 22
@@ -641,8 +641,6 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
                     if len(interval) == 2:
                         self.minLength = interval[0]
                         self.maxLength = interval[1]
-                        
-                        print(self.schemaNode.iname())
                     else:
                         self.minLength = interval[0]
 

--- a/yanggui/dataeditor.py
+++ b/yanggui/dataeditor.py
@@ -935,7 +935,9 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
             self.DisplayYangEntryInstData(data)
 
         def DisplayYangEntryInstData(self, data):
-            self.max_index = len(data.parinst.value) - 1
+            self.max_index = -1
+            if data != None:
+                self.max_index = len(data.parinst.value) - 1
             super().DisplayYangInstData(data)
             
         def DisplayYangInstData(self, data):
@@ -1141,9 +1143,10 @@ class YangListViewer(wx.Frame):
                 updated = d.insert_before(value=value).top()
             else:
                 updated = d.insert_after(value=value).top()
+            self.property.max_index += 1
+            self.env['dsrepo'].commit(updated)
         else:
-            updated = self.property.Create()
-        self.env['dsrepo'].commit(updated)
+            self.property.Create()
 
     def _OnDeleteSelected(self, e):
         item = self.list.GetFirstSelected()
@@ -1154,6 +1157,7 @@ class YangListViewer(wx.Frame):
             item = self.list.GetNextSelected(item)
         for item in sorted(remove, reverse=True):
             updatedValue = updatedValue.delete_item(item)
+        self.property.max_index -= len(remove)
         self.env['dsrepo'].commit(updatedValue.top())
 
     def RefreshInstData(self):

--- a/yanggui/dataeditor.py
+++ b/yanggui/dataeditor.py
@@ -222,7 +222,7 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
                 
             if (property.env['southboundIf'] != None) and (property.env['southboundIf'].resources != None):
                 if property.schemaNode.data_path() in property.env['southboundIf'].resources:
-                    if not property.schemaNode.config and dataValid:
+                    if property.schemaNode.config and dataValid:
                         buttons.AddButton("P", id=self.PUT)
                     buttons.AddButton("G", id=self.GET)
             if dataValid:

--- a/yanggui/dsrepo.py
+++ b/yanggui/dsrepo.py
@@ -126,9 +126,22 @@ class DataStoreRepo:
                 self._find_all_errors(entry)
         
         if isinstance(node, yangson.instance.RootNode):
-            self.errorLog = list(set(self.errorLog)) # remove duplicates
+            self._removeDuplicates()
+            self.errorLog = list(set(self.errorLog))
             self.errorLog = sorted(self.errorLog , key=lambda log: log.instance.path)
             self._notify_error_log_cbs()
+            
+    def _removeDuplicates(self):
+        errorLogClean = list()
+        for error in self.errorLog:
+            seen = False
+            for errorClean in errorLogClean:
+                if str(error) == str(errorClean):
+                    seen = True
+                    break
+            if not seen:
+                errorLogClean.append(error)
+        self.errorLog = errorLogClean
             
     def _notify_error_log_cbs(self):
         for cb in self.error_log_callbacks:

--- a/yanggui/dsrepo.py
+++ b/yanggui/dsrepo.py
@@ -171,6 +171,8 @@ class DataStoreRepo:
             return None
         d = self.datastores[name]
         for index in path:
+            if d == None:
+                return None
             if isinstance(d.value, yangson.instvalue.ArrayValue):
                 if 0 <= index < len(d.value):
                     d = d[index]

--- a/yanggui/yanggui.py
+++ b/yanggui/yanggui.py
@@ -16,8 +16,13 @@ from .dataeditor import YangPropertyGrid
 from .graphviewer import GraphViewer
 
 class MainFrame(wx.Frame):
-    def __init__(self, southboundIf):
-        wx.Frame.__init__(self, None, title="YANG GUI")
+    def __init__(self, southboundIf, title, icon):
+        wx.Frame.__init__(self, None, title=title)
+        
+        if icon != None:
+            ic = wx.Icon(name=icon, type=wx.BITMAP_TYPE_ICO)
+            self.SetIcon(ic)
+        
         self.Bind(wx.EVT_CLOSE, self._OnClose)
         self.graphViewer = None
         self.southboundIf = southboundIf
@@ -253,7 +258,7 @@ class DiffViewer(wx.Frame):
     self.SetSizer(sizer) 
     self.SetSize((700, 700)) 
     
-def main(southboundIf=None): 
+def main(southboundIf=None, title="YANG GUI", icon=None): 
     app = wx.App()
-    MainFrame(southboundIf).Show()
+    MainFrame(southboundIf, title, icon).Show()
     app.MainLoop()


### PR DESCRIPTION
Improvements:
- Making use of default values in YANG model when creating new data nodes
- When performing a GET operation for a node which does not exist, it is first created and then the GET is performed
- Providing dropdown choices for possible leafref values (including when inside a leaf-list)
- Updating the way that lists and containers are represented in the GUI. The overview of its contents is now based on the representation of the child properties. List viewer shows more details of children which are containers

Bugfixes:
- Fixed an issue that could occur when inserting a list entry into an empty list with the list viewer