### PR TITLE
Fixing an issue that could occur when switching between yang libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    version='0.1.5',
+    version='0.1.6',
     name = "yanggui",
     python_requires=">=3.6",
     install_requires=[

--- a/yanggui/dataeditor.py
+++ b/yanggui/dataeditor.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 import rstr
+import re
 import json
 import wx
 import wx.lib.scrolledpanel
@@ -766,15 +767,21 @@ class YangPropertyGrid(wxpg.PropertyGridManager):
 
         def _ConvertInstDataToValue(self, data):
             return '0x{}'.format(data.value.hex())
-        
+
     class YangStringProperty(YangLinearProperty):
         def GetDefaultValue(self):
             if hasattr(self.type, 'patterns') and len(self.type.patterns) > 0:
-                value = rstr.xeger(self.type.patterns[0].regex)
+                no_match = True
+                while (no_match):
+                    value = rstr.xeger(self.type.patterns[0].regex)
+                    no_match = False
+                    for pattern in self.type.patterns:
+                        if not re.compile(pattern.regex).match(value):
+                            no_match = True                            
             else:
                 value = rstr.rstr('x', self.minLength)
             return "\"{}\"".format(value)
-        
+
         def _ParseInstDataFromValue(self, value):
             if value == "":
                 data = None

--- a/yanggui/yanggui.py
+++ b/yanggui/yanggui.py
@@ -10,6 +10,8 @@ import wx.adv
 import wx.html2
 import yangson
 
+from pubsub import pub
+
 from .dsrepo import DataStoreRepo
 from .errorlog import ErrorLog
 from .dataeditor import YangPropertyGrid
@@ -177,6 +179,7 @@ class MainFrame(wx.Frame):
             print("Error while loading the YANG library. Exception: {} - {}".format(str(e), type(e)))
         else:
             print('Loaded Yang Library from {}'.format(libraryFile))
+            pub.unsubAll()
             self.dsrepo = DataStoreRepo(self.dm)
             if self.graphViewer == None:
                 self.graphViewer = GraphViewer(self.utilsBook, self.dsrepo, self.southboundIf)


### PR DESCRIPTION
- after loading a new library, old subscriptions stil existed, so if a node with the same path existed in the new library, data was published to a window that no longer existed
- fix is to unsubscribe all topic while doing the library switch